### PR TITLE
Add new audit button

### DIFF
--- a/src/app/(general)/dashboard/page.tsx
+++ b/src/app/(general)/dashboard/page.tsx
@@ -17,6 +17,14 @@ export default async function DashboardPage() {
   return (
     <div className='container mx-auto p-8'>
       <h1 className='text-2xl font-bold mb-4'>Your Audits</h1>
+      <div className='mb-4'>
+        <a
+          href='/'
+          className='inline-block px-4 py-2 bg-blue-600 text-white rounded'
+        >
+          New Audit
+        </a>
+      </div>
       <AuditList results={data ?? []} />
     </div>
   )


### PR DESCRIPTION
## Summary
- show a 'New Audit' button on the dashboard page so users can trigger new audits

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684e248f53d0832aaaadc9c948e283bc