### PR TITLE
Add worker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,29 @@ Run `yarn test` to execute the Vitest suite locally.
 This project is ready for Vercel. Copy `.env.example` to your Vercel environment
 variables and import `vercel.json` for configuration. Ensure the Stripe, Supabase,
 Upstash and API keys are set in the dashboard before deploying.
+
+## Running the Audit Worker
+
+The audit worker consumes jobs from the Redis queue and writes the results back to Supabase.
+It relies on the following environment variables:
+
+- `UPSTASH_REDIS_REST_URL`
+- `UPSTASH_REDIS_REST_TOKEN`
+- `APIFY_TOKEN`
+- `OPENROUTER_API_KEY`
+
+### Local execution
+
+Run the worker directly with [`tsx`](https://github.com/esbuild/tsx):
+
+```bash
+npx tsx src/jobs/auditWorker.ts
+```
+
+### Production
+
+After building the project you can invoke the compiled worker script:
+
+```bash
+yarn worker
+```

--- a/src/jobs/auditWorker.ts
+++ b/src/jobs/auditWorker.ts
@@ -1,3 +1,8 @@
+/**
+ * Processes audit jobs from the `audit-queue` in Upstash Redis and saves
+ * results back to Supabase. Run locally with `npx tsx src/jobs/auditWorker.ts`
+ * or in production via `yarn worker` after building the project.
+ */
 import { Redis } from '@upstash/redis'
 import axios from 'axios'
 import { createClient } from '@/utils/supabase/server'


### PR DESCRIPTION
## Summary
- document how to run the audit worker locally and in production
- mention env vars needed for the worker
- explain worker role at top of `auditWorker.ts`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684e485e427c832a93f1dba8535d3370