### PR TITLE
Run audit worker via tsx and loop jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ npx tsx src/jobs/auditWorker.ts
 
 ### Production
 
-After building the project you can invoke the compiled worker script:
+Invoke the worker script directly:
 
 ```bash
 yarn worker

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "worker": "node dist/jobs/auditWorker.js"
+    "worker": "tsx src/jobs/auditWorker.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.5",

--- a/src/jobs/auditWorker.ts
+++ b/src/jobs/auditWorker.ts
@@ -1,7 +1,7 @@
 /**
  * Processes audit jobs from the `audit-queue` in Upstash Redis and saves
  * results back to Supabase. Run locally with `npx tsx src/jobs/auditWorker.ts`
- * or in production via `yarn worker` after building the project.
+ * It can be invoked with `tsx` directly, e.g. `yarn worker`.
  */
 import { Redis } from '@upstash/redis'
 import axios from 'axios'
@@ -91,4 +91,15 @@ export async function processNextJob() {
       result: { engagementRate, recommendations: ai.data },
     })
   return true
+}
+
+// When executed directly, continually process jobs on an interval
+if (require.main === module) {
+  // Run immediately then every 5 seconds
+  const run = () =>
+    processNextJob().catch(err =>
+      console.error('Error processing job:', err)
+    )
+  run()
+  setInterval(run, 5000)
 }


### PR DESCRIPTION
## Summary
- run audit worker directly via tsx instead of compiled JS
- keep polling for jobs by calling `processNextJob()` on an interval
- document the new worker command

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684e7dfde444832aa9251e3c31eb8642