### PR TITLE
Update HeroForm redirect

### DIFF
--- a/src/components/home/HeroForm.tsx
+++ b/src/components/home/HeroForm.tsx
@@ -9,11 +9,15 @@ export function HeroForm() {
   const [goal, setGoal] = useState('')
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await fetch('/api/stripe/create-checkout-session', {
+    const response = await fetch('/api/stripe/create-checkout-session', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ handle, email, niche, goal }),
     })
+    const { url } = await response.json()
+    if (url) {
+      window.location.href = url
+    }
   }
 
   return (

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,3 +1,4 @@
 import Stripe from 'stripe'
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-09-30.acacia' })
+const secret = process.env.STRIPE_SECRET_KEY || 'sk_test_dummy'
+export const stripe = new Stripe(secret, { apiVersion: '2024-09-30.acacia' })

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,4 +1,7 @@
 import { createBrowserClient } from '@supabase/ssr'
 
-export const createClientContainer = () =>
-  createBrowserClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!)
+export const createClientContainer = () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost:54321'
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'anon-key'
+  return createBrowserClient(url, anonKey)
+}


### PR DESCRIPTION
## Summary
- fetch checkout session JSON in `HeroForm` and redirect to returned url
- add fallback environment variables so `yarn dev` starts without configuration

## Testing
- `yarn test`
- `yarn dev` (server started with HTTP 200 response)

------
https://chatgpt.com/codex/tasks/task_e_684e7dfcc21c832a91fef7068e421202